### PR TITLE
Add sample CSV files and documentation for Hacktoberfest

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -15,6 +15,7 @@ Title, Description, Priority, Type, Labels, Difficulty, Component
 ```bash
 GITHUB_TOKEN=your_pat_here CSV_FILE=./samples/bugs.csv npx csv-to-issues owner/repo
 ```
+You can download any sample file, edit it and run the tool to match your project.
 
-You can duplicate and edit any sample to match your project.
+To download use `wget https://github.com/krushndayshmookh/csv-to-issues/tree/main/samples/bugs.csv`
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,20 @@
+## Samples
+
+Use these CSVs as starting points for common workflows. The tool expects headers:
+
+```csv
+Title, Description, Priority, Type, Labels, Difficulty, Component
+```
+
+- **bugs.csv**: Realistic bug reports
+- **features.csv**: Feature/enhancement requests
+- **hacktoberfest.csv**: Beginner-friendly issues with `hacktoberfest` context
+
+### Running with a sample
+
+```bash
+GITHUB_TOKEN=your_pat_here CSV_FILE=./samples/bugs.csv npx csv-to-issues owner/repo
+```
+
+You can duplicate and edit any sample to match your project.
+

--- a/samples/bugs.csv
+++ b/samples/bugs.csv
@@ -1,0 +1,6 @@
+Title,Description,Priority,Type,Labels,Difficulty,Component
+"Crash on launch","App crashes on startup on macOS 14.5 when loading user profile","High","Bug","crash,stability","Medium","Core"
+"Login fails with special characters","Users cannot log in when passwords contain emojis","High","Bug","authentication,security","Easy","Core"
+"Memory leak in image viewer","Opening large images increases memory usage over time","Medium","Bug","performance,memory","Hard","UI"
+"Broken dark mode toggle","Dark mode toggle does not persist after refresh","Low","Bug","ui,theme","Easy","UI"
+

--- a/samples/features.csv
+++ b/samples/features.csv
@@ -1,0 +1,6 @@
+Title,Description,Priority,Type,Labels,Difficulty,Component
+"Add dark mode","Implement dark theme with system preference detection and toggle","Medium","Enhancement","ui,theme,accessibility","Easy","UI"
+"Export data to CSV","Allow users to export filtered results to CSV from reports page","High","Enhancement","reports,export","Medium","Core"
+"Keyboard shortcuts","Add shortcuts for common actions to improve power-user workflow","Low","Enhancement","ux,productivity,accessibility","Medium","UI"
+"Offline support","Cache critical routes and assets for limited offline usage","Medium","Enhancement","pwa,service-worker","Hard","Service"
+

--- a/samples/hacktoberfest.csv
+++ b/samples/hacktoberfest.csv
@@ -1,0 +1,6 @@
+Title,Description,Priority,Type,Labels,Difficulty,Component
+"Add CONTRIBUTING.md","Create a contributing guide with setup, code style, and PR process","Low","Enhancement","documentation,hacktoberfest","Easy","Documentation"
+"Refactor utils into modules","Split `utils.js` into focused modules with tests","Medium","Enhancement","refactor,hacktoberfest","Medium","Core"
+"Improve a11y for buttons","Ensure all buttons have accessible names and contrast","Low","Enhancement","accessibility,hacktoberfest","Easy","UI"
+"Add issue templates","Provide GitHub issue templates for bugs and features","Low","Enhancement","community,hacktoberfest","Easy","Documentation"
+


### PR DESCRIPTION
Fixes #20  

This PR adds a new **`samples/`** folder containing:

- **`bugs.csv`** – Example bug reports with realistic fields  
- **`features.csv`** – Feature/enhancement request samples  
- **`hacktoberfest.csv`** – Beginner-friendly issues for Hacktoberfest participants  
- **`README.md`** – Documentation on how to use the sample CSVs and run the tool  

as mentioned in the issue .
